### PR TITLE
Do not use system-site-packages by default

### DIFF
--- a/vars/virtualenv.groovy
+++ b/vars/virtualenv.groovy
@@ -1,16 +1,27 @@
-def call(String name, List packages=[]) {
+def call(String name, List packages=[], Boolean system_site_package=false) {
+	// --system-site-packages injection string
+	def ssp_str = ""
 	def path = "${WORKSPACE}/${name}"
 	if ( path.contains(" ") ) {
 		throw new Exception("Path cannot include a space")
 	}
-	// Ensure we hvae a fresh path
+
+	// Handle the addition of system-site-packages if requested
+	if ( system_site_packages ) {
+		ssp_str = "--system-site-packages"
+	}
+
+	// Ensure we have a fresh path
 	sh "rm -rf '${path}'"
-	sh """virtualenv --no-setuptools --system-site-packages '${path}'
-	      . '${path}/bin/activate'
-	      curl https://bootstrap.pypa.io/get-pip.py | python
-	      '${path}/bin/python' '${path}/bin/pip' install -U setuptools
-    """
-    if ( packages ) {
-	    sh "'${path}/bin/python' '${path}/bin/pip' install ${packages.join(' ')}"
-    }
+
+	// setup the virtualenv, and then install the latest pip and setuptools
+	sh """virtualenv --no-setuptools ${ssp_str} '${path}'
+		  . '${path}/bin/activate'
+		  curl https://bootstrap.pypa.io/get-pip.py | python
+		  '${path}/bin/python' '${path}/bin/pip' install -U setuptools
+	"""
+
+	if ( packages ) {
+		sh "'${path}/bin/python' '${path}/bin/pip' install ${packages.join(' ')}"
+	}
 }


### PR DESCRIPTION
This passes lint, but I'm not actually sure if it'll work. We really
shouldn't be including system site-packages, since it messes up test env
isolation, unless I'm missing a compelling reason for it.